### PR TITLE
[#6308] tdk latest jar

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,9 +4,7 @@
 mkdir -p $HOME/.tdk/bin
 
 # Fetch the latest JAR file
-# FIXME: select latest version automatically 
-# LATEST_JAR_URL=$(curl -s https://synthesizedio.jfrog.io/artifactory/tdk-public/ | grep -o 'href="[^"]*.jar"' | sed 's/href="//;s/"//' | grep -E '_v[0-9]+\.[0-9]+\.[0-9]+\.jar$' | sort -t. -k2,2n -k3,3n -k4,4n | tail -n 1)
-LATEST_JAR_URL="synthesized_tdk_v1.100.0.jar"
+LATEST_JAR_URL="synthesized_tdk_latest.jar"
 curl -L -o $HOME/.tdk/latest.jar "https://governor-static.synthesized.io/jars-public/$LATEST_JAR_URL"
 
 # Create a wrapper shell script

--- a/install.sh
+++ b/install.sh
@@ -3,9 +3,10 @@
 # Create necessary directories
 mkdir -p $HOME/.tdk/bin
 
-# Fetch the latest JAR file
-LATEST_JAR_URL="synthesized_tdk_latest.jar"
-curl -L -o $HOME/.tdk/latest.jar "https://governor-static.synthesized.io/jars-public/$LATEST_JAR_URL"
+# Fetch the latest/specified JAR file
+TDK_VERSION=${TDK_VERSION:-"latest"}
+TDK_JAR="synthesized_tdk_${TDK_VERSION}.jar"
+curl -L -o $HOME/.tdk/latest.jar "https://governor-static.synthesized.io/jars-public/$TDK_JAR"
 
 # Create a wrapper shell script
 cat > $HOME/.tdk/bin/tdk << EOF


### PR DESCRIPTION
Fix #6308

## Overview

Fix install.sh to fetch the latest JAR file with name "synthesized_tdk_latest.jar". It's related with https://github.com/synthesized-io/tdk/pull/6400.


## Checklist before requesting a review

- [N/A] Change is covered by automated tests.
- [N/A] Documentation is updated.
- [N/A] Changelog entry is included.
- [X] PR is properly tagged.